### PR TITLE
[Hacktoberfest] Migrate docs to jenkinsci repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,7 @@
     This plugin provides a build step that generates mock load on the build node for use when testing
     Jenkins scalability.
   </description>
-  <!-- TODO import to GitHub -->
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Mock+Load+Builder+Plugin</url>
+  <url>http://github.com/jenkinsci/mock-load-builder-plugin</url>
   <licenses>
     <license>
       <name>The MIT license</name>


### PR DESCRIPTION
This PR migrates the Mock Load Builder plugin docs from the wiki to GitHub as part of the Hacktoberfest docs-to-code project. All that was required for this plugin was to update the pom.xml file with the new URL for the docs.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did