### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.31</version>
+    <version>4.32</version>
     <relativePath/>
   </parent>
 
@@ -62,7 +62,7 @@
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/mock-load-builder-plugin</gitHubRepo>
     <java.level>8</java.level>
-    <!-- TODO define jenkins.version -->
+    <jenkins.version>2.289.1</jenkins.version>
     <spotbugs.skip>true</spotbugs.skip> <!-- not for production anyway -->
   </properties>
 
@@ -81,16 +81,18 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jenkins-ci</groupId>
-      <artifactId>symbol-annotation</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>variant</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>junit</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -133,9 +135,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.176.x</artifactId>
-        <!-- TODO set up Dependabot -->
-        <version>16</version>
+        <artifactId>bom-2.289.x</artifactId>
+        <version>1075.v14bef33e5d7b</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/jenkins/plugin/mockloadbuilder/Config.java
+++ b/src/main/java/jenkins/plugin/mockloadbuilder/Config.java
@@ -7,7 +7,7 @@ import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.StaplerRequest;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.jenkinsci.Symbol;
 
 @Symbol("mockLoad")
@@ -70,7 +70,7 @@ public class Config extends GlobalConfiguration {
         this.matrixMultiplier = matrixMultiplier;
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public String getDisplayName() {
         return "Mock Load Builder";

--- a/src/main/java/jenkins/plugin/mockloadbuilder/MockLoadBuilder.java
+++ b/src/main/java/jenkins/plugin/mockloadbuilder/MockLoadBuilder.java
@@ -16,7 +16,7 @@ import hudson.tasks.Builder;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -35,7 +35,7 @@ public class MockLoadBuilder extends Builder implements SimpleBuildStep {
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener) throws InterruptedException, IOException {
+    public void perform(@NonNull Run<?, ?> run, @NonNull FilePath workspace, @NonNull Launcher launcher, @NonNull TaskListener listener) throws InterruptedException, IOException {
         if (MockProjectFactory.mode) {
             workspace.act(workspace.asCallableWith(new NoFork(averageDuration, listener)));
         } else {


### PR DESCRIPTION
Supersedes #19. See https://github.com/jenkinsci/plugin-pom/pull/456#issuecomment-1002215478.

```
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for javax.mail:mail:1.4.4 [provided] paths to dependency are:
+-org.jenkins-ci.plugins:mock-load-builder:999999-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-core:2.204 [provided]
    +-javax.mail:mail:1.4.4 [provided]
and
+-org.jenkins-ci.plugins:mock-load-builder:999999-SNAPSHOT
  +-org.jenkins-ci.plugins.workflow:workflow-basic-steps:2.20
    +-org.jenkins-ci.plugins:mailer:1.32.1 (managed) <-- org.jenkins-ci.plugins:mailer:1.32
      +-javax.mail:mail:1.4.7 [provided]
and
+-org.jenkins-ci.plugins:mock-load-builder:999999-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-core:2.204 [provided]
    +-org.springframework:spring-webmvc:2.5.6.SEC03 [provided]
      +-org.springframework:spring-context-support:2.5.6.SEC03 [provided]
        +-javax.mail:mail:1.4 [provided]
]
```

Maybe related to https://github.com/jenkinsci/jenkins/pull/4660 & https://github.com/jenkinsci/jenkins/pull/4702.
